### PR TITLE
Added GitHub CI build and push images version 8.0, 8.1, 8.2

### DIFF
--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -1,0 +1,43 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-build-release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - { mysql: 8.2}
+          - { mysql: 8.1}
+          - { mysql: 8.0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_REGISTRY_USER }}
+          password: ${{ secrets.CI_REGISTRY_TOKEN }}
+
+      - name: Builds and pushes Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_IMAGE }}:${{ matrix.mysql }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Hi-Technix, Inc. <support@hitechnix.com>"
 
 ARG TARGETARCH
 
-COPY ./conf/install.sh install.sh
+COPY ./src/install.sh install.sh
 RUN sh install.sh && rm install.sh
 
 ENV MYSQL_DATABASE ''


### PR DESCRIPTION
- Added GitHub CI build and push images version 8.0, 8.1, 8.2
- Github CI ran successfully on my fork, please check [here](https://github.com/trants/mysql-backup/actions)